### PR TITLE
Correção na paginação das listas de items

### DIFF
--- a/site/component/model/jsitemodellist-simple.sublime-snippet
+++ b/site/component/model/jsitemodellist-simple.sublime-snippet
@@ -63,8 +63,8 @@ class ${TM_COMPONENT/(.+)/\u\1/g}Model${1:${TM_FILENAME/(.*?)(\..+)/\u$1/}} exte
 		\$app = JFactory::getApplication();
 
 		// List state information.
-		\$value = \$app->input->get('limit', \$app->getCfg('list_limit', 0), 'uint');
-		\$this->setState('list.limit', \$value);
+		\$limit = \$app->getUserStateFromRequest('global.list.limit', 'limit', \$app->getCfg('list_limit'), 'uint');
+		\$this->setState('list.limit', \$limit);
 
 		\$value = \$app->input->get('limitstart', 0, 'uint');
 		\$this->setState('list.start', \$value);


### PR DESCRIPTION
A listagem dos itens não estavam sendo paginadas de maneira correta. Depois da solicitação de uma próxima página ela voltava a ser listada com a quantidade de lista padrão do Joomla! ("$app->getCfg('list_limit')") sem considerar o que tinha sido selecionado como quantidade a listar. Para isso era necessário assumir a quantidade selecionada pelo usuário através da chamada "getUserStateFromRequest". Esse teste e correção foi realizado no Joomla! 3.2.3! Espero ter colaborado...
